### PR TITLE
Unpushed commits (local main ahead of origin/main)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,8 @@
     "authors": [
         {
             "name": "Sebastian Bürgin-Fix",
-            "email": "sebastian.buergin@buergin.ch",
+            "email": "helpdesk@codebar.ch",
             "homepage": "https://www.codebar.ch",
-            "role": "Sofware-Engineer"
-        },
-        {
-            "name": "Rhys Lees",
             "role": "Software-Engineer"
         }
     ],


### PR DESCRIPTION
Local main was 2 commit(s) ahead of origin/main. Opened from update-opensource-active.sh for review.